### PR TITLE
Enhanced IRX loader conditions

### DIFF
--- a/engine/src/ps2/irx/irx_loader.cpp
+++ b/engine/src/ps2/irx/irx_loader.cpp
@@ -109,9 +109,9 @@ int IrxLoader::applyRpcPatches() {
 void IrxLoader::loadLibsd(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading libsd...");
 
-  int ret;
-  SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: libsd_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: libsd_irx");
 
   if (verbose) TYRA_LOG("IRX: Libsd loaded!");
 }
@@ -119,19 +119,19 @@ void IrxLoader::loadLibsd(const bool& verbose) {
 void IrxLoader::loadUsbModules(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading usb modules...");
 
-  int ret;
+  int ret, irx_id;
 
-  SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: usbd_irx");
+  irx_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: usbd_irx ret:", ret, ", id:", irx_id);
 
-  SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: bdm_irx");
+  irx_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: bdm_irx ret:", ret, ", id:", irx_id);
 
-  SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: bdmfs_fatfs");
+  irx_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: bdmfs_fatfs ret:", ret, ", id:", irx_id);
 
-  SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: usbmass");
+  irx_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: usbmass ret:", ret, ", id:", irx_id);
 
   waitUntilUsbDeviceIsReady();
 
@@ -141,9 +141,9 @@ void IrxLoader::loadUsbModules(const bool& verbose) {
 void IrxLoader::loadAudsrv(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading audsrv...");
 
-  int ret;
-  SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: audsrv_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: audsrv_irx ret:", ret, ", id:", irx_id);
 
   if (verbose) TYRA_LOG("IRX: Audsrv loaded!");
 }
@@ -151,9 +151,9 @@ void IrxLoader::loadAudsrv(const bool& verbose) {
 void IrxLoader::loadSio2man(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading sio2man...");
 
-  int ret;
-  SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: sio2man_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: sio2man_irx ret:", ret, ", id:", irx_id);
 
   if (verbose) TYRA_LOG("IRX: Sio2man loaded!");
 }
@@ -161,9 +161,9 @@ void IrxLoader::loadSio2man(const bool& verbose) {
 void IrxLoader::loadPadman(const bool& verbose) {
   if (verbose) TYRA_LOG("IRX: Loading padman...");
 
-  int ret;
-  SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, nullptr, &ret);
-  TYRA_ASSERT(ret >= 0, "Failed to load module: padman_irx");
+  int ret, irx_id;
+  irx_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, nullptr, &ret);
+  TYRA_ASSERT(((ret != 1) || (irx_id < 0)), "Failed to load module: padman_irx ret:", ret, ", id:", irx_id);
 
   if (verbose) TYRA_LOG("IRX: Padman loaded!");
 }


### PR DESCRIPTION
An error happened if either IRX ID is less than 0 (error reported by MODLOAD itself, eg: missing IRX dependency), or if return value is 1 (aka: module returned NO_RESIDENT_END, aka: module willingly asked to be removed from RAM )